### PR TITLE
Correct the default date format

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -2,4 +2,4 @@
 
 $conf['git_exec'] 		= '/usr/bin/git';
 $conf['root_dir'] 		= '';
-$conf['date_format'] 	= 'd.m.Y H:m';
+$conf['date_format'] 	= 'd.m.Y H:i';


### PR DESCRIPTION
Adapt the character for the minutes in the date format.
The correct character is "i".
